### PR TITLE
hg-agent-periodic: log in `config_once`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME=hg-agent
-VERSION=1.2
+VERSION=1.3
 ARCH=amd64
 
 docker:

--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ pip install pyinstaller==3.1.1    \
             supervisor==3.3.1     \
             diamond==4.0.451      \
             psutil==5.1.3         \
-            'git+ssh://git@github.com/metricfire/hg-agent-periodic.git@cb6e2ca81fe685917ad6a5785058d3a896da9d06#egg=hg_agent_periodic'
+            'git+ssh://git@github.com/metricfire/hg-agent-periodic.git@96b389f882e8958929dea146c49b71aed0bbffac#egg=hg_agent_periodic'
 
 # Workaround a PyInstaller issue with namespaced packages, cf. goo.gl/CnuoMo
 touch /hg-agent.venv/lib/python2.7/site-packages/supervisor/__init__.py


### PR DESCRIPTION
Version update for
  https://github.com/metricfire/hg-agent-periodic/pull/1