### PR TITLE
Version 1.15 of the agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME=hg-agent
-VERSION=1.14
+VERSION=1.15
 ARCH=amd64
 
 docker:

--- a/build.sh
+++ b/build.sh
@@ -25,8 +25,8 @@ pip install pyinstaller==3.1.1    \
             psutil==5.1.3         \
             multitail2==1.4.1     \
             pymongo==3.5.1       \
-            'git+ssh://git@github.com/hostedgraphite/hg-agent-periodic.git@a496c507689b634acf3efdd6076e61698504f511#egg=hg_agent_periodic'\
-            'git+ssh://git@github.com/hostedgraphite/hg-agent-forwarder.git@6d3939e42a8d2df80c737136da803c33bb61ae0d#egg=hg_agent_forwarder'
+            'git+ssh://git@github.com/hostedgraphite/hg-agent-periodic.git@fb2ec635152839d72170d11d3d07c46370132702#egg=hg_agent_periodic'\
+            'git+ssh://git@github.com/hostedgraphite/hg-agent-forwarder.git@a39bcbedb402befd08859f92a8c8f57469d23011#egg=hg_agent_forwarder'
 # Workaround a PyInstaller issue with namespaced packages, cf. goo.gl/CnuoMo
 touch /hg-agent.venv/lib/python2.7/site-packages/supervisor/__init__.py
 

--- a/etc/supervisor.conf
+++ b/etc/supervisor.conf
@@ -33,6 +33,7 @@ directory=/var/opt/hg-agent
 [program:receiver]
 command=/opt/hg-agent/bin/receiver --config=/etc/opt/hg-agent/hg-agent.conf
 stdout_logfile=/var/log/hg-agent/receiver.log
+redirect_stderr=true
 autostart=true
 autorestart=true
 startsecs=10
@@ -43,6 +44,7 @@ directory=/var/opt/hg-agent
 [program:forwarder]
 command=/opt/hg-agent/bin/forwarder --config=/etc/opt/hg-agent/hg-agent.conf
 stdout_logfile=/var/log/hg-agent/forwarder.log
+redirect_stderr=true
 autostart=true
 autorestart=true
 startsecs=10


### PR DESCRIPTION
Fixes and improves many UX & system features, incorporating the
following changes:

*   `endpoint` is no longer mandatory, meaning only  `api_key` is
    necessary in the agent's configuration for most users;
    (https://github.com/hostedgraphite/hg-agent-periodic/pull/10)

*   the `config` tool can now specify HTTP metric sink & heartbeat
    metadata endpoints, for use by users with a large dedicated Hosted
    Graphite environment;
    (https://github.com/hostedgraphite/hg-agent-periodic/pull/11)

*   the `forwarder` & `receiver` sub-processes now restart properly
    when relevant configuration changes (including the HTTP metric
    sink);
    (https://github.com/hostedgraphite/hg-agent-periodic/pull/12,
     https://github.com/hostedgraphite/hg-agent-periodic/pull/13)

*   shutdown & "backoff" handling (during connection issues) are
    improved in the `forwarder`;
    (https://github.com/hostedgraphite/hg-agent-forwarder/pull/6)

*   logging output is clearer & parts of the code touched by the above
    are better documented.