### PR TITLE
Bump version for release to Ubuntu cosmic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME=hg-agent
-VERSION=1.17
+VERSION=1.18
 ARCH=amd64
 
 docker:


### PR DESCRIPTION
This is not strictly necessary - nothing in the package itself has
changed - but our package repository doesn't expect re-upload of an
existing version, so this makes getting the new `cosmic` build out there
straightforward.